### PR TITLE
fix dictionary key name

### DIFF
--- a/jpeg_benchmark.py
+++ b/jpeg_benchmark.py
@@ -104,7 +104,7 @@ def run():
         max_compression_ratio = 0
         total_compression_ratio = 0
 
-        current_result = results[f"quality_{quality}"]
+        current_result = results[f"lossy_{quality}"]
 
         for frame_index in range(FRAME_COUNT):
             image = Image.open(pathlib.Path(INPUT_PATH, f"{frame_index}.png")) # load one at a time


### PR DESCRIPTION
When testing, found a small typo in the `jpeg_benchamrk.py`. This is the fixed version used in the test.